### PR TITLE
Update Gmail docs

### DIFF
--- a/packages/twenty-website/src/content/releases/0.3.3.mdx
+++ b/packages/twenty-website/src/content/releases/0.3.3.mdx
@@ -5,7 +5,7 @@ Date: Mar 19th 2024
 
 # Gmail integration
 
-Connect your Gmail account to automatically associate emails with relevant 'People' and 'Companies'. Contacts you've emailed will be automatically added to 'People', excluding non-personal emails like ﻿support@ and ﻿team@. Control your privacy by selecting the information you share with your team.
+Connect your personal Gmail account to automatically associate emails with relevant 'People' and 'Companies'. Contacts you've emailed will be automatically added to 'People', excluding non-personal emails like ﻿support@ and ﻿team@. Control your privacy by selecting exactly how much email content is shared with your team.
 
 ![](/images/releases/0.3.3_emails.png)
 

--- a/packages/twenty-website/src/content/user-guide/functions/emails.mdx
+++ b/packages/twenty-website/src/content/user-guide/functions/emails.mdx
@@ -8,7 +8,7 @@ sectionInfo: Learn how to connect Twenty to your other tools.
 
 ## Email Synchronization
 
-The system links emails from known contacts directly to their CRM records, keeping all communication up to date. It's important to avoid syncing emails from impersonal addresses such as team@ and support@, or from personal email providers like Gmail or Outlook, to ensure privacy and relevance.
+The system links emails from known contacts directly to their CRM records, keeping all communication up to date. You can connect a personal Gmail account and decide how much of each email you share with your team, ranging from full content to just metadata.
 
 
 ### Internal Emails


### PR DESCRIPTION
## Summary
- clarify that users can sync personal Gmail accounts
- mention privacy controls in Gmail release notes

## Testing
- `yarn test` *(fails: unable to reach yarn registry)*

------
https://chatgpt.com/codex/tasks/task_e_6863b07461108321912af82b9996db1c